### PR TITLE
Add solutions for different versions of visual studio and add debugging docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,139 @@
+# top-most EditorConfig file
+root = true
+
+# Global settings
+[*]
+indent_style = space
+end_of_line = crlf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.cs]
+indent_size = 4
+
+[*.{config,xml}]
+indent_size = 2
+
+[*.{proj,props,sln,targets}]
+tab_width = 4
+
+[*.{csproj,json,ps1,psd1,psm1,resx,rst}]
+indent_size = 2
+
+[nuget.config]
+indent_size = 2
+
+
+# Advanced
+dotnet_sort_system_directives_first = true
+
+###############
+# Code Style
+###############
+# 'this.' preferences
+dotnet_style_qualification_for_field = true:none
+dotnet_style_qualification_for_property = true:none
+dotnet_style_qualification_for_method = true:none
+dotnet_style_qualification_for_event = true:none
+
+# Predefined type preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:none
+dotnet_style_predefined_type_for_member_access = true:none
+
+# 'var' preferences
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:suggestion
+
+# Code block preferences
+############ Missing Prefer braces = true:warning
+csharp_style_expression_bodied_methods = false:none
+csharp_style_expression_bodied_constructors = false:none
+csharp_style_expression_bodied_operators = false:none
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_indexers = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+
+# Expression preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+dotnet_style_explicit_tuple_names = true:warning
+
+# Variable preferences
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# 'null' checking
+csharp_style_throw_expression = true:none
+csharp_style_conditional_delegate_call = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+
+###############
+# Indentation
+###############
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+#############
+# New Lines
+#############
+# New line options for braces
+csharp_new_line_before_open_brace = all
+
+# New line options for keywords
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+
+# New line options for expressions
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+###########
+# Spacing
+###########
+# Set spacing for method declarations
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+
+# Set spacing for method calls
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+
+# Set other spacing options
+csharp_space_after_keywords_in_control_flow_statements = true
+# csharp_space_between_parentheses = none
+csharp_space_after_cast = false
+csharp_space_around_declaration_statements = do_not_ignore
+
+# Set spacing for brackets
+csharp_space_before_open_square_brackets = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_square_brackets = false
+
+# Set spacing for delimiters
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_semicolon_in_for_statement = false
+
+# Set spacing for operators
+csharp_space_around_binary_operators = before_and_after
+
+###########
+# Wrapping
+###########
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,11 +30,11 @@ before_build:
   - cd src
   - appveyor DownloadFile https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
   - appveyor DownloadFile https://raw.githubusercontent.com/appveyor/ci/master/scripts/nuget-restore.cmd
-  - nuget-restore
+  - nuget-restore SpecFlow.xUnitAdapter.2017.sln
   - cd ..
 
 build:
-  project: src\SpecFlow.xUnitAdapter.sln
+  project: src\SpecFlow.xUnitAdapter.2017.sln
   verbosity: normal
 
 artifacts:

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,40 @@
+# Debugging SpecFlow xUnitAdapter
+In order to debug the SpecFlow xUnitAdapter, you will need to be able to attach the debugger to the process running/discovering tests. Unfortunatly, `vstest.console.exe` kicks off child processes when it runs/discovers tests. The easiest solution to this is to use an extension created by an employee at Microsoft that instructs the Visual Studio Debugger to attach to and child process spawned from the process currently attached to the debugger. You can download and install the extension from: [Microsoft Child Process Debugging Power Tool](https://visualstudiogallery.msdn.microsoft.com/a1141bff-463f-465f-9b6d-d29b7b503d7a).
+
+Once the extension is installed open the `SpecFlow.xUnitAdapter.SpecFlowPlugin` project's properties and go to the `Debug` property page.
+
+## Start external program:
+Visual Studio 2015:
+```
+C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe
+```
+
+Visual Studio 2017:
+```
+C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\Extensions\TestPlatform\vstest.console.exe
+```
+
+## Command line arguments:
+This property will change depending on what you are trying to debug. The most common scenarios are:
+
+Test Discovery:
+```
+SpecFlow.xUnitAdapter.TestProject.dll /ListTests /TestAdapterPath:.
+```
+
+Test Run:
+```
+SpecFlow.xUnitAdapter.TestProject.dll /TestAdapterPath:.
+```
+
+## Working directory:
+This should be set to the bin directory of the test project which may be different on your machine. An example might be:
+```
+C:\Projects\SpecFlow.xUnitAdapter\src\tests\SpecFlow.xUnitAdapter.TestProject\bin\Debug\
+```
+
+## Enable native code debugging:
+This option needt to be enabled so that the child process debugging tools work.
+
+## Microsoft Child Process Debugging Power Tool Configuration
+The settings for the child process debugging are stored in the `src\SpecFlow.xUnitAdapter.2017.ChildProcessDbgSettings` file. These settings should be already configured to work correctly with the SpecFlow adapter, however if you need to modify the settings you can do so in Visual Studio using the following menu: `Debug -> Other Debug Targets -> Child Process Debugging Settings...`

--- a/src/SpecFlow.xUnitAdapter.2015.ChildProcessDbgSettings
+++ b/src/SpecFlow.xUnitAdapter.2015.ChildProcessDbgSettings
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ChildProcessDebuggingSettings IsEnabled="true" xmlns="http://schemas.microsoft.com/vstudio/ChildProcessDebuggingSettings/2014">
+  <DefaultRule EngineFilter="[inherit]" />
+  <Rule IsEnabled="false" ProcessName="" EngineFilter="[inherit]" />
+</ChildProcessDebuggingSettings>

--- a/src/SpecFlow.xUnitAdapter.2015.sln
+++ b/src/SpecFlow.xUnitAdapter.2015.sln
@@ -11,10 +11,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGetPackages", "NuGetPacka
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4DBA1825-0282-4C5D-A1DF-764DAA47216D}"
 	ProjectSection(SolutionItems) = preProject
+		..\.editorconfig = ..\.editorconfig
 		..\appveyor.yml = ..\appveyor.yml
 		..\LICENSE = ..\LICENSE
 		.nuget\nuget.config = .nuget\nuget.config
 		..\README.md = ..\README.md
+		SpecFlow.xUnitAdapter.2015.ChildProcessDbgSettings = SpecFlow.xUnitAdapter.2015.ChildProcessDbgSettings
 	EndProjectSection
 EndProject
 Global

--- a/src/SpecFlow.xUnitAdapter.2017.ChildProcessDbgSettings
+++ b/src/SpecFlow.xUnitAdapter.2017.ChildProcessDbgSettings
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<ChildProcessDebuggingSettings IsEnabled="true" xmlns="http://schemas.microsoft.com/vstudio/ChildProcessDebuggingSettings/2014">
+  <DefaultRule EngineFilter="[inherit]" />
+  <Rule IsEnabled="false" ProcessName="" EngineFilter="[inherit]" />
+</ChildProcessDebuggingSettings>

--- a/src/SpecFlow.xUnitAdapter.2017.sln
+++ b/src/SpecFlow.xUnitAdapter.2017.sln
@@ -1,0 +1,44 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26419.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpecFlow.xUnitAdapter.SpecFlowPlugin", "SpecFlow.xUnitAdapter.SpecFlowPlugin\SpecFlow.xUnitAdapter.SpecFlowPlugin.csproj", "{1DD1877B-E008-4383-AE65-69A55264C5BA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpecFlow.xUnitAdapter.TestProject", "tests\SpecFlow.xUnitAdapter.TestProject\SpecFlow.xUnitAdapter.TestProject.csproj", "{23B6FA2E-CFB0-4D32-A40D-D29C8CC8DF45}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuGetPackages", "NuGetPackages\NuGetPackages.csproj", "{B967FFB8-7BF4-4889-99BF-D8B4FA6A0B5A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4DBA1825-0282-4C5D-A1DF-764DAA47216D}"
+	ProjectSection(SolutionItems) = preProject
+		..\.editorconfig = ..\.editorconfig
+		..\appveyor.yml = ..\appveyor.yml
+		..\LICENSE = ..\LICENSE
+		.nuget\nuget.config = .nuget\nuget.config
+		..\README.md = ..\README.md
+		SpecFlow.xUnitAdapter.2017.ChildProcessDbgSettings = SpecFlow.xUnitAdapter.2017.ChildProcessDbgSettings
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1DD1877B-E008-4383-AE65-69A55264C5BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1DD1877B-E008-4383-AE65-69A55264C5BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1DD1877B-E008-4383-AE65-69A55264C5BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1DD1877B-E008-4383-AE65-69A55264C5BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{23B6FA2E-CFB0-4D32-A40D-D29C8CC8DF45}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{23B6FA2E-CFB0-4D32-A40D-D29C8CC8DF45}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{23B6FA2E-CFB0-4D32-A40D-D29C8CC8DF45}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{23B6FA2E-CFB0-4D32-A40D-D29C8CC8DF45}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B967FFB8-7BF4-4889-99BF-D8B4FA6A0B5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B967FFB8-7BF4-4889-99BF-D8B4FA6A0B5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B967FFB8-7BF4-4889-99BF-D8B4FA6A0B5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B967FFB8-7BF4-4889-99BF-D8B4FA6A0B5A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
- I added a solution file for VS2017 and renamed the VS2015 file.
- I updated the appveyor build to use the 2017 solution file since it is setup to use Visual Studio 2017.
- Added an editorconfig file to help prevent me from deviating from the code standards (feel free to modify this if you disagree with any of the settings I picked)
- Added docs describing how to setup Visual Studio to debug the adapter plugin

If you merge this PR, I will update my other branches since there will be conflicts with the editorconfig and sln files.

Thanks!