### PR TITLE
Make explicit its requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,15 @@
 SpecFlow.xUnitAdapter is an xUnit adapter for SpecFlow that allows running 
 scenarios without code generation.
 
-Currently supports
+Supports:
+
 * SpecFlow v2.2
 * xUnit v2.2 or above
+
+Requires:
+
+* .NET Framework 4.5 or above
+* Visual Studio for Windows
 
 License: Apache (https://github.com/gasparnagy/SpecFlow.xUnitAdapter/blob/master/LICENSE)
 


### PR DESCRIPTION
After seeing this [video](https://www.youtube.com/watch?v=wGuoVqG3I8M&t=8m45s) we had hoped that we would be able to build and run test in .NET Core. We were wrong, because it still has a dependency on .NET Framework.

This edit makes it more explicit.